### PR TITLE
Creating main definition

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,6 +106,18 @@ app.get("/", function(req, res){
                 	})
                 		
             }     
+
+            // Creating Main Definition when there no group of definitions, like the words "is" or "are"
+            if (JSON.stringify(dictionary.meaning) == '{"":[{}]}') {
+                var definition = $(grambs[0]).text();
+                dictionary.meaning = {
+                    'Main definition': [
+                        {
+                            "definition": definition
+                        }
+                    ]
+                }
+            }        
             
             Object.keys(dictionary).forEach(key => {(Array.isArray(dictionary[key]) && !dictionary[key].length) && delete dictionary[key]});
             


### PR DESCRIPTION
Some words don't return a definition like the words "is" and "are".
So, I did a few adjustments. When this kind of situation happens, I set up an initial definition.

I don't know whether this was the best way to resolve. Feel free to add or change any code.

